### PR TITLE
fix: preserve user preferences on profile updates

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -110,8 +110,16 @@ export class AuthService {
   static async updateProfile(updates: Partial<User>): Promise<User> {
     const currentUser = this.getCurrentUser()
     if (!currentUser) throw new Error('No user logged in')
+    const mergedPreferences = updates.preferences
+      ? { ...currentUser.preferences, ...updates.preferences }
+      : currentUser.preferences
 
-    const updatedUser = { ...currentUser, ...updates }
+    const updatedUser = {
+      ...currentUser,
+      ...updates,
+      preferences: mergedPreferences
+    }
+
     localStorage.setItem(this.STORAGE_KEY, JSON.stringify(updatedUser))
     return updatedUser
   }


### PR DESCRIPTION
## Summary
- ensure `updateProfile` merges nested preference settings instead of replacing them

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6894521ebdfc832dab2a914d14ff4261