### PR TITLE
Add premium features page

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,0 +1,66 @@
+import { Heart, ArrowLeft } from "lucide-react";
+import Link from "next/link";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+export default function AboutPage() {
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-amber-50 to-orange-50">
+      {/* Header */}
+      <header className="bg-white shadow-sm border-b border-amber-200">
+        <div className="max-w-6xl mx-auto px-6 py-4">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center space-x-3">
+              <Heart className="h-8 w-8 text-amber-600" />
+              <h1 className="text-2xl font-bold text-gray-800">
+                Livets Stemme
+              </h1>
+            </div>
+            <Link
+              href="/"
+              className="flex items-center text-amber-600 hover:text-amber-700 font-medium"
+            >
+              <ArrowLeft className="mr-2 h-5 w-5" />
+              Tilbake til Hjem
+            </Link>
+          </div>
+        </div>
+      </header>
+
+      <main className="max-w-4xl mx-auto px-6 py-12">
+        <div className="text-center mb-12">
+          <h2 className="text-4xl font-bold text-gray-800 mb-4">Om Oss</h2>
+          <p className="text-xl text-gray-600">
+            Vi ønsker å gjøre det enkelt for alle å bevare og dele sine
+            livshistorier.
+          </p>
+        </div>
+        <Card className="border-amber-200 shadow-lg">
+          <CardHeader>
+            <CardTitle className="text-2xl text-gray-800">
+              Vår Historie
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4 text-lg text-gray-600">
+            <p>
+              Livets Stemme er utviklet for å gi et varmt og trygt rom for
+              fortellinger. Prosjektet ledes av{" "}
+              <span className="font-semibold">Sven Inge Henningsen</span>, som
+              arbeider i <span className="font-semibold">Forfatterskolen</span>{" "}
+              og <span className="font-semibold">Easywrite</span>.
+            </p>
+            <p>
+              Gjennom arbeidet med skriveglade mennesker har vi sett behovet for
+              et enkelt verktøy som hjelper deg å ta vare på minnene dine – med
+              din egen stemme.
+            </p>
+            <p>
+              Vi tror at alle historier fortjener å bli hørt. Ved å kombinere
+              inspirasjon fra skrivefellesskapet og moderne teknologi håper vi
+              at flere får mot til å dele sine minner.
+            </p>
+          </CardContent>
+        </Card>
+      </main>
+    </div>
+  );
+}

--- a/src/app/premium/page.tsx
+++ b/src/app/premium/page.tsx
@@ -1,0 +1,62 @@
+import { Heart, ArrowLeft } from "lucide-react";
+import Link from "next/link";
+import { Card, CardContent } from "@/components/ui/card";
+
+export default function PremiumPage() {
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-amber-50 to-orange-50">
+      {/* Header */}
+      <header className="bg-white shadow-sm border-b border-amber-200">
+        <div className="max-w-6xl mx-auto px-6 py-4">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center space-x-3">
+              <Heart className="h-8 w-8 text-amber-600" />
+              <h1 className="text-2xl font-bold text-gray-800">Livets Stemme</h1>
+            </div>
+            <Link href="/" className="flex items-center text-amber-600 hover:text-amber-700 font-medium">
+              <ArrowLeft className="mr-2 h-5 w-5" />
+              Tilbake til Hjem
+            </Link>
+          </div>
+        </div>
+      </header>
+
+      <main className="max-w-4xl mx-auto px-6 py-12">
+        <div className="text-center mb-12">
+          <h2 className="text-4xl font-bold text-gray-800 mb-4">Premium Funksjoner</h2>
+          <p className="text-xl text-gray-600">
+            Få tilgang til avanserte AI-funksjoner og ubegrenset lagring
+          </p>
+        </div>
+        <Card className="border-amber-200 shadow-lg">
+          <CardContent className="p-8 space-y-8 text-lg text-gray-600">
+            <div>
+              <h3 className="text-2xl font-bold text-gray-800 mb-2">🎭 Stemmekloning</h3>
+              <p>
+                ElevenLabs AI kan lære din stemme og hjelpe med å fullføre historier eller lage nye opptak i din stemme.
+              </p>
+            </div>
+            <div>
+              <h3 className="text-2xl font-bold text-gray-800 mb-2">📝 Automatisk Transkripsjon</h3>
+              <p>
+                Få tekstversjoner av alle opptakene dine automatisk, med mulighet for redigering og søk.
+              </p>
+            </div>
+            <div>
+              <h3 className="text-2xl font-bold text-gray-800 mb-2">👥 Utvidet Familie-deling</h3>
+              <p>
+                Inviter ubegrenset antall familiemedlemmer og lag private familiesamlinger av historier.
+              </p>
+            </div>
+            <div>
+              <h3 className="text-2xl font-bold text-gray-800 mb-2">🧠 AI Historieassistent</h3>
+              <p>
+                Få personlige historieforslag basert på din alder, bakgrunn og interesser.
+              </p>
+            </div>
+          </CardContent>
+        </Card>
+      </main>
+    </div>
+  );
+}

--- a/src/components/HomeContent.tsx
+++ b/src/components/HomeContent.tsx
@@ -42,6 +42,7 @@ export default function HomeContent() {
                 <Link href="/stories" className="text-lg text-gray-700 hover:text-amber-600 font-medium">Mine Historier</Link>
                 <Link href="/help" className="text-lg text-gray-700 hover:text-amber-600 font-medium">Hjelp</Link>
                 <Link href="/listen" className="text-lg text-gray-700 hover:text-amber-600 font-medium">Lytt & Del</Link>
+                <Link href="/premium" className="text-lg text-gray-700 hover:text-amber-600 font-medium">Premium</Link>
               </nav>
               <div className="flex items-center space-x-4">
                 <div className="flex items-center space-x-2">
@@ -114,6 +115,7 @@ export default function HomeContent() {
               <nav className="hidden md:flex space-x-8">
                 <Link href="/help" className="text-lg text-gray-700 hover:text-amber-600 font-medium">Hjelp</Link>
                 <Link href="/about" className="text-lg text-gray-700 hover:text-amber-600 font-medium">Om Oss</Link>
+                <Link href="/premium" className="text-lg text-gray-700 hover:text-amber-600 font-medium">Premium</Link>
               </nav>
               <Button
                 onClick={() => setShowLogin(true)}


### PR DESCRIPTION
## Summary
- add about page describing Livets Stemme and Sven Inge Henningsen
- introduce premium features page detailing voice cloning, automatic transcription, expanded family sharing, and an AI story assistant
- link premium page in navigation for both authenticated and guest users

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689b180a8e84832db884beeaf700b89f