### PR TITLE
Add premium voice cloning feature

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,0 +1,66 @@
+import { Heart, ArrowLeft } from "lucide-react";
+import Link from "next/link";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+export default function AboutPage() {
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-amber-50 to-orange-50">
+      {/* Header */}
+      <header className="bg-white shadow-sm border-b border-amber-200">
+        <div className="max-w-6xl mx-auto px-6 py-4">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center space-x-3">
+              <Heart className="h-8 w-8 text-amber-600" />
+              <h1 className="text-2xl font-bold text-gray-800">
+                Livets Stemme
+              </h1>
+            </div>
+            <Link
+              href="/"
+              className="flex items-center text-amber-600 hover:text-amber-700 font-medium"
+            >
+              <ArrowLeft className="mr-2 h-5 w-5" />
+              Tilbake til Hjem
+            </Link>
+          </div>
+        </div>
+      </header>
+
+      <main className="max-w-4xl mx-auto px-6 py-12">
+        <div className="text-center mb-12">
+          <h2 className="text-4xl font-bold text-gray-800 mb-4">Om Oss</h2>
+          <p className="text-xl text-gray-600">
+            Vi ønsker å gjøre det enkelt for alle å bevare og dele sine
+            livshistorier.
+          </p>
+        </div>
+        <Card className="border-amber-200 shadow-lg">
+          <CardHeader>
+            <CardTitle className="text-2xl text-gray-800">
+              Vår Historie
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4 text-lg text-gray-600">
+            <p>
+              Forfatterskolen er et skrivefellesskap for alle som ønsker å
+              utvikle pennen sin. Siden oppstarten har vi tilbudt kurs,
+              veiledning og inspirasjon til tusenvis av nye og erfarne
+              forfatterspirer.
+            </p>
+            <p>
+              Vi brenner for å skape et varmt og inkluderende miljø hvor
+              historier kan vokse frem. Med støtte fra erfarne veiledere og
+              engasjerte medforfattere får du mot til å dele din stemme.
+            </p>
+            <p>
+              Livets Stemme springer ut av dette engasjementet. Prosjektet ledes
+              av <span className="font-semibold">Sven Inge Henningsen</span>,
+              som arbeider i <span className="font-semibold">Forfatterskolen</span>
+              og <span className="font-semibold">Easywrite</span>.
+            </p>
+          </CardContent>
+        </Card>
+      </main>
+    </div>
+  );
+}

--- a/src/app/api/voice-clone/route.ts
+++ b/src/app/api/voice-clone/route.ts
@@ -1,0 +1,49 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export async function POST(request: NextRequest) {
+  try {
+    const formData = await request.formData();
+    const audio = formData.get("audio") as Blob | null;
+    const voiceName = formData.get("voiceName") as string | null;
+
+    if (!audio || !voiceName) {
+      return NextResponse.json(
+        { error: "Missing audio file or voice name" },
+        { status: 400 },
+      );
+    }
+
+    const apiKey = process.env.ELEVENLABS_API_KEY;
+    if (!apiKey) {
+      return NextResponse.json(
+        { error: "ELEVENLABS_API_KEY not configured" },
+        { status: 500 },
+      );
+    }
+
+    const elevenForm = new FormData();
+    elevenForm.append("name", voiceName);
+    elevenForm.append("files", audio, "sample.wav");
+
+    const response = await fetch("https://api.elevenlabs.io/v1/voices/add", {
+      method: "POST",
+      headers: {
+        "xi-api-key": apiKey,
+      },
+      body: elevenForm,
+    });
+
+    const data = await response.json();
+    if (!response.ok) {
+      return NextResponse.json({ error: data }, { status: response.status });
+    }
+
+    return NextResponse.json(data);
+  } catch (error) {
+    console.error(error);
+    return NextResponse.json(
+      { error: "Failed to clone voice" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/premium/page.tsx
+++ b/src/app/premium/page.tsx
@@ -1,0 +1,87 @@
+import { Heart, ArrowLeft } from "lucide-react";
+import Link from "next/link";
+import { Card, CardContent } from "@/components/ui/card";
+
+export default function PremiumPage() {
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-amber-50 to-orange-50">
+      {/* Header */}
+      <header className="bg-white shadow-sm border-b border-amber-200">
+        <div className="max-w-6xl mx-auto px-6 py-4">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center space-x-3">
+              <Heart className="h-8 w-8 text-amber-600" />
+              <h1 className="text-2xl font-bold text-gray-800">
+                Livets Stemme
+              </h1>
+            </div>
+            <Link
+              href="/"
+              className="flex items-center text-amber-600 hover:text-amber-700 font-medium"
+            >
+              <ArrowLeft className="mr-2 h-5 w-5" />
+              Tilbake til Hjem
+            </Link>
+          </div>
+        </div>
+      </header>
+
+      <main className="max-w-4xl mx-auto px-6 py-12">
+        <div className="text-center mb-12">
+          <h2 className="text-4xl font-bold text-gray-800 mb-4">
+            Premium Funksjoner
+          </h2>
+          <p className="text-xl text-gray-600">
+            Få tilgang til avanserte AI-funksjoner og ubegrenset lagring
+          </p>
+        </div>
+        <Card className="border-amber-200 shadow-lg">
+          <CardContent className="p-8 space-y-8 text-lg text-gray-600">
+            <div>
+              <h3 className="text-2xl font-bold text-gray-800 mb-2">
+                🎭 Stemmekloning
+              </h3>
+              <p>
+                ElevenLabs AI kan lære din stemme og hjelpe med å fullføre
+                historier eller lage nye opptak i din stemme.
+              </p>
+              <Link
+                href="/premium/voice-cloning"
+                className="text-amber-600 hover:text-amber-700 underline"
+              >
+                Prøv stemmekloning
+              </Link>
+            </div>
+            <div>
+              <h3 className="text-2xl font-bold text-gray-800 mb-2">
+                📝 Automatisk Transkripsjon
+              </h3>
+              <p>
+                Få tekstversjoner av alle opptakene dine automatisk, med
+                mulighet for redigering og søk.
+              </p>
+            </div>
+            <div>
+              <h3 className="text-2xl font-bold text-gray-800 mb-2">
+                👥 Utvidet Familie-deling
+              </h3>
+              <p>
+                Inviter ubegrenset antall familiemedlemmer og lag private
+                familiesamlinger av historier.
+              </p>
+            </div>
+            <div>
+              <h3 className="text-2xl font-bold text-gray-800 mb-2">
+                🧠 AI Historieassistent
+              </h3>
+              <p>
+                Få personlige historieforslag basert på din alder, bakgrunn og
+                interesser.
+              </p>
+            </div>
+          </CardContent>
+        </Card>
+      </main>
+    </div>
+  );
+}

--- a/src/app/premium/voice-cloning/page.tsx
+++ b/src/app/premium/voice-cloning/page.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { Heart, ArrowLeft } from "lucide-react";
+
+export default function VoiceCloningPage() {
+  const [status, setStatus] = useState<string | null>(null);
+
+  async function handleSubmit(formData: FormData) {
+    setStatus("Laster...");
+    const response = await fetch("/api/voice-clone", {
+      method: "POST",
+      body: formData,
+    });
+    const data = await response.json();
+    if (response.ok) {
+      setStatus(
+        "Stemmen er klonet! ID: " + (data.voice_id || data.voice?.voice_id),
+      );
+    } else {
+      setStatus("Feil: " + (data.error?.message || JSON.stringify(data)));
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-amber-50 to-orange-50">
+      <header className="bg-white shadow-sm border-b border-amber-200">
+        <div className="max-w-6xl mx-auto px-6 py-4">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center space-x-3">
+              <Heart className="h-8 w-8 text-amber-600" />
+              <h1 className="text-2xl font-bold text-gray-800">
+                Livets Stemme
+              </h1>
+            </div>
+            <Link
+              href="/premium"
+              className="flex items-center text-amber-600 hover:text-amber-700 font-medium"
+            >
+              <ArrowLeft className="mr-2 h-5 w-5" />
+              Tilbake til Premium
+            </Link>
+          </div>
+        </div>
+      </header>
+      <main className="max-w-xl mx-auto px-6 py-12">
+        <h2 className="text-3xl font-bold text-gray-800 mb-6">Stemmekloning</h2>
+        <form action={handleSubmit} className="space-y-4">
+          <div className="space-y-2">
+            <label htmlFor="voiceName" className="font-medium">
+              Navn på stemme
+            </label>
+            <input
+              id="voiceName"
+              name="voiceName"
+              type="text"
+              required
+              className="w-full border rounded px-3 py-2"
+            />
+          </div>
+          <div className="space-y-2">
+            <label htmlFor="audio" className="font-medium">
+              Lydfil
+            </label>
+            <input
+              id="audio"
+              name="audio"
+              type="file"
+              accept="audio/*"
+              required
+              className="w-full"
+            />
+          </div>
+          <button
+            type="submit"
+            className="bg-amber-600 text-white px-4 py-2 rounded"
+          >
+            Last opp og klon
+          </button>
+        </form>
+        {status && <p className="mt-4 text-gray-700">{status}</p>}
+      </main>
+    </div>
+  );
+}

--- a/src/components/HomeContent.tsx
+++ b/src/components/HomeContent.tsx
@@ -42,6 +42,7 @@ export default function HomeContent() {
                 <Link href="/stories" className="text-lg text-gray-700 hover:text-amber-600 font-medium">Mine Historier</Link>
                 <Link href="/help" className="text-lg text-gray-700 hover:text-amber-600 font-medium">Hjelp</Link>
                 <Link href="/listen" className="text-lg text-gray-700 hover:text-amber-600 font-medium">Lytt & Del</Link>
+                <Link href="/premium" className="text-lg text-gray-700 hover:text-amber-600 font-medium">Premium</Link>
               </nav>
               <div className="flex items-center space-x-4">
                 <div className="flex items-center space-x-2">
@@ -114,6 +115,7 @@ export default function HomeContent() {
               <nav className="hidden md:flex space-x-8">
                 <Link href="/help" className="text-lg text-gray-700 hover:text-amber-600 font-medium">Hjelp</Link>
                 <Link href="/about" className="text-lg text-gray-700 hover:text-amber-600 font-medium">Om Oss</Link>
+                <Link href="/premium" className="text-lg text-gray-700 hover:text-amber-600 font-medium">Premium</Link>
               </nav>
               <Button
                 onClick={() => setShowLogin(true)}


### PR DESCRIPTION
## Summary
- enable ElevenLabs integration for cloning voices via new `/api/voice-clone` route
- add "Stemmekloning" page with upload form and link from premium page
- expand "Om Oss" page with background text from Forfatterskolen

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689b180a8e84832db884beeaf700b89f